### PR TITLE
Improve traffic allocation

### DIFF
--- a/src/Bucketer.ts
+++ b/src/Bucketer.ts
@@ -4,7 +4,7 @@ import { Allocation } from './Config';
 
 class Bucketer {
   static HASH_SEED = 1;
-  static MAX_HASH_VALUE = Math.pow(2, 32);
+  static MAX_HASH_VALUE = Math.pow(2, 32) - 1;
 
   private maxBuckets: number;
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -36,7 +36,7 @@ class Config {
   }
 
   private computeRangeEnd(percentage: number): number {
-    return (this.maxBuckets * percentage) / 100;
+    return (percentage * this.maxBuckets) / 100;
   }
 
   getExperiments(): { [id: string]: Experiment } {
@@ -71,13 +71,25 @@ class Config {
     return { id, rangeEnd };
   }
 
+  getExperimentAllocation(id: string): Allocation | undefined {
+    const experiment = this.getExperiment(id);
+
+    if (!experiment) {
+      return;
+    }
+
+    const rangeEnd = this.computeRangeEnd(experiment.percentage);
+
+    return { id, rangeEnd };
+  }
+
   getExperimentAllocations(id: string): Array<Allocation> {
     const experiment = this.getExperiment(id);
     let acc = 0;
 
     return experiment.variations.map(({ id, percentage }) => {
       acc += percentage / 100;
-      const rangeEnd = acc * this.computeRangeEnd(experiment.percentage);
+      const rangeEnd = acc * this.maxBuckets;
 
       return { id, rangeEnd };
     });

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -36,7 +36,7 @@ class Config {
   }
 
   private computeRangeEnd(percentage: number): number {
-    return (percentage * this.maxBuckets) / 100;
+    return Math.floor((percentage * this.maxBuckets) / 100);
   }
 
   getExperiments(): { [id: string]: Experiment } {
@@ -88,8 +88,8 @@ class Config {
     let acc = 0;
 
     return experiment.variations.map(({ id, percentage }) => {
-      acc += percentage / 100;
-      const rangeEnd = acc * this.maxBuckets;
+      acc += percentage;
+      const rangeEnd = this.computeRangeEnd(acc);
 
       return { id, rangeEnd };
     });

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -18,7 +18,7 @@ class Engine {
     datafile,
     userId,
     attributes,
-    storage,
+    storage
   }: {
     datafile: Datafile;
     storage?: Storage<string>;
@@ -92,7 +92,7 @@ class Engine {
     return Object.keys(features).reduce((features, featureId) => {
       return {
         ...features,
-        [featureId]: this.isFeatureEnabled(featureId, userId, attributes),
+        [featureId]: this.isFeatureEnabled(featureId, userId, attributes)
       };
     }, {});
   }
@@ -145,7 +145,7 @@ class Engine {
     return Object.keys(experiments).reduce((experiments, experimentId) => {
       return {
         ...experiments,
-        [experimentId]: this.getVariationId(experimentId, userId, attributes),
+        [experimentId]: this.getVariationId(experimentId, userId, attributes)
       };
     }, {});
   }

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -5,6 +5,7 @@ import Storage from './Storage';
 
 class Engine {
   static readonly TOTAL_BUCKETS = 10000;
+  static readonly TRAFFIC_ALLOCATION_SALT = 'tas';
 
   private config: Config;
   private bucketer: Bucketer;
@@ -120,7 +121,7 @@ class Engine {
       return null;
     }
 
-    let key = this.computeKey(experimentId, userId, 'audience');
+    let key = this.computeKey(experimentId, userId, Engine.TRAFFIC_ALLOCATION_SALT);
     const allocation = this.config.getExperimentAllocation(experimentId);
 
     if (!allocation || !this.bucketer.bucket(key, [allocation])) {
@@ -130,7 +131,7 @@ class Engine {
     key = this.computeKey(experimentId, userId);
     const allocations = this.config.getExperimentAllocations(experimentId);
 
-    variationId = this.bucketer.bucket(this.computeKey(experimentId, userId), allocations);
+    variationId = this.bucketer.bucket(key, allocations);
     this.storage?.store(experimentId, variationId);
 
     return variationId;

--- a/test/Config.spec.ts
+++ b/test/Config.spec.ts
@@ -34,16 +34,20 @@ describe('Config', () => {
 
   test('should get experiment allocations', () => {
     const config = new Config(datafile, TOTAL_BUCKETS);
-    const allocations = config.getExperimentAllocations('experiment-1');
+    const allocations = config.getExperimentAllocations('experiment-2');
 
     expect(allocations).toEqual([
       {
         id: '0',
-        rangeEnd: 3000
+        rangeEnd: 3400
       },
       {
         id: '1',
-        rangeEnd: 7000
+        rangeEnd: 6700
+      },
+      {
+        id: '2',
+        rangeEnd: 10000
       }
     ]);
   });

--- a/test/Engine.spec.ts
+++ b/test/Engine.spec.ts
@@ -3,25 +3,53 @@ import Engine from '../src/Engine';
 import * as datafile from './fixtures/datafile.json';
 
 describe('Engine', () => {
-  test('should bucket experiment into a variation', () => {
+  test('should allocate experiment inside variation', () => {
     const userId = '676380e0-7793-44d6-9189-eb5868e17a86';
     const engine = new Engine({ datafile, userId });
 
     expect(engine.getVariationId('experiment-1')).toBe('0');
   });
 
-  test('should bucket experiment outside a variation', () => {
+  test('should not allocate experiment inside variation', () => {
     const userId = '111180e0-7793-44d6-9189-eb5868e17a86';
     const engine = new Engine({ datafile, userId });
 
     expect(engine.getVariationId('experiment-1')).toBeNull();
   });
 
-  test('should bucket experiment outside a variation', () => {
+  test('should not allocate experiment inside variation due traffic allocation', () => {
     const userId = '111180e0-7793-44d6-9189-eb5868e17a86';
     const engine = new Engine({ datafile, userId });
 
-    expect(engine.getVariationId('experiment-1')).toBeNull();
+    expect(engine.getVariationId('experiment-2')).toBeNull();
+  });
+
+  test('should allocate experiment inside same variation regarding traffic allocation change', () => {
+    const userId = '676380e0-7793-44d6-9189-eb5868e17aqq';
+    const { experiments } = datafile;
+    const experimentId = 'experiment-2';
+    const variationId = '2';
+    let engine;
+
+    engine = new Engine({ datafile, userId });
+
+    expect(engine.getVariationId(experimentId)).toBe(variationId);
+
+    engine = new Engine({
+      datafile: {
+        ...datafile,
+        experiments: {
+          ...experiments,
+          [experimentId]: {
+            ...experiments[experimentId],
+            percentage: 100
+          }
+        }
+      },
+      userId
+    });
+
+    expect(engine.getVariationId(experimentId)).toBe(variationId);
   });
 
   test('should get all variations', () => {
@@ -42,13 +70,6 @@ describe('Engine', () => {
     engine.setUserId('111180e0-7793-44d6-9189-eb5868e17a86');
 
     expect(engine.getVariationId('experiment-1')).toBeNull();
-  });
-
-  test('should not allocate experiment inside variation', () => {
-    const userId = '111180e0-7793-44d6-9189-eb5868e17a86';
-    const engine = new Engine({ datafile, userId });
-
-    expect(engine.getVariationId('experiment-2')).toBeNull();
   });
 
   test('should match audience before bucketing experiment', () => {

--- a/test/fixtures/datafile.json
+++ b/test/fixtures/datafile.json
@@ -13,10 +13,16 @@
     },
     "experiment-2": {
       "id": "experiment-2",
-      "percentage": 0,
+      "percentage": 30,
       "variations": [{
         "id": "0",
-        "percentage": 100
+        "percentage": 34
+      }, {
+        "id": "1",
+        "percentage": 33
+      }, {
+        "id": "2",
+        "percentage": 33
       }]
     },
     "experiment-3": {


### PR DESCRIPTION
This PR attends to improve traffic allocation. Users were allocated to different experiment when changing it.
To check that the change is working properly, the following test was made:
```json
{
  "experiments": {
    "experiment-2": {
      "id": "experiment-2",
      "percentage": "33|66|100",
      "variations": [
        {
          "id": "0",
          "percentage": 34
        },
        {
          "id": "1",
          "percentage": 33
        },
        {
          "id": "2",
          "percentage": 33
        }
      ]
    }
  }
}
```
The following table shows how many times a `variationId` was assigned to a user for each audience allocation. If a user changes from one `variationId` to another an error will be counted.

**Before**
|Percentage   |1   |2   |3   |Errors   |
|---|---|---|---|---|
|33   |11122   |10838   |10840   |0   |
|66   |22276   |21783   |21861   |21678   |
|100   |33807   |33106   |33086   |33392   |

**After**
|Percentage   |1   |2   |3   |Errors   |
|---|---|---|---|---|
|33   |11324   |10812   |10888   |0   |
|66   |22519   |21673   |21694   |0   |
|100   |34097   |33116   |32786   |0   |

Also `MAX_HASH_VALUE` was fixed. Now is:

```javascript
const MAX_HASH_VALUE = Max.pow(2, 32) - 1
```